### PR TITLE
Two fixes to rebro/gossip

### DIFF
--- a/rebro/gossip/broadcaster.go
+++ b/rebro/gossip/broadcaster.go
@@ -93,7 +93,7 @@ func (bro *Broadcaster) Stop(ctx context.Context) (err error) {
 }
 
 func (bro *Broadcaster) Broadcast(ctx context.Context, msg rebro.Message, qcomm rebro.QuorumCertificate) error {
-	r, err := bro.rounds.StartRound(msg.ID.Round(), qcomm)
+	r, err := bro.rounds.NewRound(ctx, msg.ID.Round(), qcomm)
 	if err != nil {
 		return err
 	}
@@ -124,8 +124,7 @@ func (bro *Broadcaster) Broadcast(ctx context.Context, msg rebro.Message, qcomm 
 		return err
 	}
 
-	// TODO: Delayed stopped to collect more signatures
-	return bro.rounds.StopRound(ctx, msg.ID.Round())
+	return nil
 }
 
 // broadcastGossip prepares and publishes a gossip to the network.


### PR DESCRIPTION
* [fix(rebro/gossip): synchronize round starts and stops](https://github.com/iykyk-syn/unison/commit/b63f8aa442841d9c43fde27417e225c058ec941f)
 * New rounds have to be started atomically with the previous round stopped. Otherwise, the delay between round r stopping and round r+1 starting may get some message processing routines deadlocked until context is cancelled, harming peer score
* [refactor(rebro/gossip): use RWMutex and readbility improvements](https://github.com/iykyk-syn/unison/commit/383fa1035bfbf3ea6cb6c8ddadd612c4e041e0f1)
 * Slightly refactors round.Manager and uses RWMutex 