### PR TITLE
fix(poc): await connections

### DIFF
--- a/unison-poc/bootstrap/bootstrap.go
+++ b/unison-poc/bootstrap/bootstrap.go
@@ -89,6 +89,7 @@ func (serv *Service) Start(ctx context.Context, bootstrapper peer.AddrInfo) erro
 		return err
 	}
 
+	wg.Wait()
 	serv.log.Debug("started")
 	return nil
 }


### PR DESCRIPTION
While looking into #56, I figured that we were missing the `Wait` call when connecting to the peers. The network could start before the topology is formed.
